### PR TITLE
Configurando postgresql no projeto

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,8 @@ gem "rails", "~> 7.1.3"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 
-# Use sqlite3 as the database for Active Record
-gem "sqlite3", "~> 1.4"
+# Use postgresql as the database for Active Record
+gem "pg"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
+    pg (1.5.5)
+    pg (1.5.5-x64-mingw-ucrt)
     psych (5.1.2)
       stringio
     public_suffix (5.0.4)
@@ -211,8 +213,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.2-x64-mingw-ucrt)
-    sqlite3 (1.7.2-x86_64-linux)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
@@ -251,11 +251,11 @@ DEPENDENCIES
   debug
   importmap-rails
   jbuilder
+  pg
   puma (>= 5.0)
   rails (~> 7.1.3)
   selenium-webdriver
   sprockets-rails
-  sqlite3 (~> 1.4)
   stimulus-rails
   turbo-rails
   tzinfo-data

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,19 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem "sqlite3"
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  encoding: unicode
+  host: localhost
+  username: postgres
+  password: 07082020
 
 development:
   <<: *default
-  database: storage/development.sqlite3
+  database: ecommerce_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: storage/test.sqlite3
+  database: ecommerce_test
 
 production:
   <<: *default
-  database: storage/production.sqlite3
+  database: ecommerce_production


### PR DESCRIPTION
Alteramos e adicionamos configurações relacionadas à conexão da aplicação, que antes conectava com o SQLite3 para conexão com o PostgreSQL.